### PR TITLE
v1.1.0 -- Custom Campaign Setup Options

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright © 2020 Matthew D. Hall
+Copyright © 2020-2021 Matthew D. Hall
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/src/Config.cs
+++ b/src/Config.cs
@@ -9,16 +9,24 @@
         internal static bool PromptForPlayerName { get; set; } = false;
         internal static bool PromptForClanName { get; set; } = false;
         internal static bool OpenBannerEditor { get; set; } = false;
+        internal static bool LandownerStart { get; set; } = false;
+        internal static bool VassalStart { get; set; } = false;
+        internal static bool KingStart { get; set; } = false;
+        internal static string KingdomId { get; set; } = string.Empty;
 
         internal static void CopyFrom(McmSettings settings)
         {
-            ShowCultureStage    = settings.ShowCultureStage;
-            ShowFaceGenStage    = settings.ShowFaceGenStage;
-            ShowGenericStage    = settings.ShowGenericStage;
-            DisableIntroVideo   = settings.DisableIntroVideo;
+            ShowCultureStage = settings.ShowCultureStage;
+            ShowFaceGenStage = settings.ShowFaceGenStage;
+            ShowGenericStage = settings.ShowGenericStage;
+            DisableIntroVideo = settings.DisableIntroVideo;
             PromptForPlayerName = settings.PromptForPlayerName;
-            PromptForClanName   = settings.PromptForClanName;
-            OpenBannerEditor    = settings.OpenBannerEditor;
+            PromptForClanName = settings.PromptForClanName;
+            OpenBannerEditor = settings.OpenBannerEditor;
+            LandownerStart = settings.LandownerStart;
+            VassalStart = settings.VassalStart;
+            KingStart = settings.KingStart;
+            KingdomId = settings.KingdomId;
         }
 
         internal static string ToDebugString()
@@ -29,7 +37,10 @@
                    $"{nameof(DisableIntroVideo)}   = {DisableIntroVideo}\n" +
                    $"{nameof(PromptForPlayerName)} = {PromptForPlayerName}\n" +
                    $"{nameof(PromptForClanName)}   = {PromptForClanName}\n" +
-                   $"{nameof(OpenBannerEditor)}    = {OpenBannerEditor}";
+                   $"{nameof(OpenBannerEditor)}    = {OpenBannerEditor}\n" +
+                   $"{nameof(VassalStart)}         = {VassalStart}\n" +
+                   $"{nameof(KingStart)}           = {KingStart}\n" +
+                   $"{nameof(KingdomId)}           = {KingdomId}";
         }
     }
 }

--- a/src/Config.cs
+++ b/src/Config.cs
@@ -38,9 +38,10 @@
                    $"{nameof(PromptForPlayerName)} = {PromptForPlayerName}\n" +
                    $"{nameof(PromptForClanName)}   = {PromptForClanName}\n" +
                    $"{nameof(OpenBannerEditor)}    = {OpenBannerEditor}\n" +
+                   $"{nameof(LandownerStart)}      = {LandownerStart}\n" +
                    $"{nameof(VassalStart)}         = {VassalStart}\n" +
                    $"{nameof(KingStart)}           = {KingStart}\n" +
-                   $"{nameof(KingdomId)}           = {KingdomId}";
+                   $"{nameof(KingdomId)}           = {(string.IsNullOrWhiteSpace(KingdomId) ? "<BLANK>" : KingdomId)}";
         }
     }
 }

--- a/src/McmSettings.cs
+++ b/src/McmSettings.cs
@@ -1,5 +1,6 @@
 ﻿using MCM.Abstractions.Attributes;
 using MCM.Abstractions.Attributes.v2;
+using MCM.Abstractions.Dropdown;
 using MCM.Abstractions.Settings.Base.Global;
 
 namespace QuickStart
@@ -10,6 +11,14 @@ namespace QuickStart
         public override string DisplayName => SubModule.DisplayName;
         public override string FolderName => SubModule.Name;
         public override string FormatType => "json2";
+
+        public McmSettings()
+        {
+            _vassalStart = Config.VassalStart;
+            _kingStart = Config.KingStart;
+        }
+
+        // CHARACTER CREATION MENUS
 
         [SettingPropertyBool("Show Culture Selection Menu", HintText = ShowCultureStage_Hint, RequireRestart = false, Order = 0)]
         [SettingPropertyGroup("Character Creation Menus", GroupOrder = 0)]
@@ -22,6 +31,18 @@ namespace QuickStart
         [SettingPropertyBool("Show Generic Backstory Menus", HintText = ShowGenericStage_Hint, RequireRestart = false, Order = 2)]
         [SettingPropertyGroup("Character Creation Menus")]
         public bool ShowGenericStage { get; set; } = Config.ShowGenericStage;
+
+        private const string ShowCultureStage_Hint = "Do not skip this menu. Otherwise, a random and valid culture option"
+            + " will automatically be chosen. [ DEFAULT: OFF ]";
+
+        private const string ShowFaceGenStage_Hint = "Do not skip this menu. Else, character will use default slider values."
+            + " [ DEFAULT: OFF ]";
+
+        private const string ShowGenericStage_Hint = "Do not skip these menus. Else, random valid backstory menu options will"
+            + " be chosen. If using a mod that adds more start options from which you want to select, then enable this."
+            + " [ DEFAULT: OFF ]";
+
+        // OTHER STARTUP SETTINGS
 
         [SettingPropertyBool("Disable Intro Video", HintText = DisableIntroVideo_Hint, RequireRestart = false, Order = 0)]
         [SettingPropertyGroup("Other Startup Settings", GroupOrder = 1)]
@@ -39,16 +60,6 @@ namespace QuickStart
         [SettingPropertyGroup("Other Startup Settings")]
         public bool OpenBannerEditor { get; set; } = Config.OpenBannerEditor;
 
-        private const string ShowCultureStage_Hint = "Do not skip this menu. Otherwise, a random and valid culture option"
-            + " will automatically be chosen. [ DEFAULT: OFF ]";
-
-        private const string ShowFaceGenStage_Hint = "Do not skip this menu. Else, character will use default slider values."
-            + " [ DEFAULT: OFF ]";
-
-        private const string ShowGenericStage_Hint = "Do not skip these menus. Else, random valid backstory menu options will"
-            + " be chosen. If using a mod that adds more start options from which you want to select, then enable this."
-            + " [ DEFAULT: OFF ]";
-
         private const string DisableIntroVideo_Hint = "Disable TaleWorlds's time-consuming intro video / logo sequence upon"
             + " game start. [ DEFAULT: ON ]";
 
@@ -60,5 +71,69 @@ namespace QuickStart
 
         private const string OpenBannerEditor_Hint = "At start, automatically open the Banner Editor. Note that you can simply"
             + " hit the key 'B' (by default) to open it at any time. [ DEFAULT: OFF ]";
+
+        // CAMPAIGN SETUP OPTIONS
+
+        [SettingPropertyBool("Start with an Existing Clan's Fiefs", HintText = LandownerStart_Hint, RequireRestart = false, Order = 0)]
+        [SettingPropertyGroup("Campaign Setup", GroupOrder = 2)]
+        public bool LandownerStart { get; set; } = Config.LandownerStart;
+
+        [SettingPropertyBool("Start as a Vassal", HintText = VassalStart_Hint, RequireRestart = false, Order = 0)]
+        [SettingPropertyGroup("Campaign Setup/Kingdom Options")]
+        public bool VassalStart
+        {
+            get => _vassalStart;
+            set
+            {
+                if (_vassalStart != value)
+                {
+
+                    if (value && _kingStart)
+                        KingStart = false;
+
+                    _vassalStart = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        [SettingPropertyBool("Start as a King", HintText = KingStart_Hint, RequireRestart = false, Order = 1)]
+        [SettingPropertyGroup("Campaign Setup/Kingdom Options")]
+        public bool KingStart
+        {
+            get => _kingStart;
+            set
+            {
+                if (_kingStart != value)
+                {
+                    if (value && _vassalStart)
+                        VassalStart = false;
+
+                    _kingStart = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        [SettingPropertyText("Kingdom ID", HintText = KingdomId_Hint, RequireRestart = false, Order = 2)]
+        [SettingPropertyGroup("Campaign Setup/Kingdom Options")]
+        public string KingdomId { get; set; } = Config.KingdomId;
+
+        private const string LandownerStart_Hint = "Take the fiefs of an existing clan and start with them in your domain."
+            + " An existing clan will be selected inside your chosen kingdom, if you so choose. Else, they'll be picked"
+            + " according to your character's culture. [ DEFAULT: OFF ]";
+
+        private const string VassalStart_Hint = "Start as a vassal to a kingdom. The chosen kingdom will be picked"
+            + " first by explicit specification in the 'Kingdom ID' option and otherwise by culture. [ DEFAULT: OFF ]";
+
+        private const string KingStart_Hint = "Start as the sovereign ruler of a kingdom. The chosen kingdom will be picked"
+            +" first by explicit specification in the 'Kingdom ID' option and otherwise by culture. [ DEFAULT: OFF ]";
+
+        private const string KingdomId_Hint = "If either vassal or king start options were chosen in the previous settings, then"
+            + " it's possible to specify the exact kingdom/faction ID here (e.g., empire_s). Else, leave it blank and a kingdom"
+            + " will be chosen according to your character's culture. Careful to use a correct faction ID. [ Default: <BLANK> ]";
+
+        private bool _vassalStart;
+        private bool _kingStart;
     }
 }

--- a/src/McmSettings.cs
+++ b/src/McmSettings.cs
@@ -130,7 +130,7 @@ namespace QuickStart
 
         private const string KingdomId_Hint = "If either vassal or king start options were chosen in the previous settings, then"
             + " it's possible to specify the exact kingdom/faction ID here (e.g., empire_s). Else, leave it blank and a kingdom"
-            + " will be chosen according to your character's culture. Careful to use a correct faction ID. [ Default: <BLANK> ]";
+            + " will be chosen according to your character's culture. Careful to use a correct faction ID. [ Default: BLANK ]";
 
         private bool _vassalStart;
         private bool _kingStart;

--- a/src/McmSettings.cs
+++ b/src/McmSettings.cs
@@ -87,7 +87,6 @@ namespace QuickStart
             {
                 if (_vassalStart != value)
                 {
-
                     if (value && _kingStart)
                         KingStart = false;
 
@@ -127,7 +126,7 @@ namespace QuickStart
             + " first by explicit specification in the 'Kingdom ID' option and otherwise by culture. [ DEFAULT: OFF ]";
 
         private const string KingStart_Hint = "Start as the sovereign ruler of a kingdom. The chosen kingdom will be picked"
-            +" first by explicit specification in the 'Kingdom ID' option and otherwise by culture. [ DEFAULT: OFF ]";
+            + " first by explicit specification in the 'Kingdom ID' option and otherwise by culture. [ DEFAULT: OFF ]";
 
         private const string KingdomId_Hint = "If either vassal or king start options were chosen in the previous settings, then"
             + " it's possible to specify the exact kingdom/faction ID here (e.g., empire_s). Else, leave it blank and a kingdom"

--- a/src/QuickStart.csproj
+++ b/src/QuickStart.csproj
@@ -1,13 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>1.0.1</Version>
+    <Version>1.1.0</Version>
     <ModuleName>QuickStart</ModuleName>
-    <GameFolder>$(BANNERLORD_GAME_DIR)</GameFolder>
     <TargetFramework>net472</TargetFramework>
     <Platforms>x64</Platforms>
     <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
+    
+    <!--
+    <GameFolder>$(BANNERLORD_GAME_DIR)</GameFolder>
+    -->
+    <GameFolder>$(BANNERLORD_STABLE_DIR)</GameFolder>
+    <!--
+    <GameFolder>$(BANNERLORD_BETA_DIR)</GameFolder>
+    -->
   </PropertyGroup>
 
   <ItemGroup>
@@ -41,7 +48,7 @@
     <PackageReference Include="Bannerlord.MCM" Version="4.1.2" />
     <PackageReference Include="Lib.Harmony" Version="2.0.4" IncludeAssets="compile" />
     <PackageReference Include="Bannerlord.ButterLib" Version="1.0.18" IncludeAssets="compile" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" PrivateAssets="All" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" IncludeAssets="compile" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Includes options to:

- Start With an Existing Clan's Fiefs
  - Based on the other options (or lack thereof), picks a relatively good clan from which to yank at least a town
  - Leaves the other clan landless
  - If starting as a King, it'll always try to unland the scripted ruler clan of that kingdom, as you are taking over
- Start as a Vassal
  - Decent amount of start money, initial gear from a tier 3-4 cavalry troop, and a party of 25 (relatively low-level troops, however)
- Start as a King
  - Solid amount of influence, starting gold, initial gear from a tier 5-8 cavalry troop, a party of 50 with a solid tier spread ratio, plenty of food, and mules to pack it
  - Oh, yeah, and you're the damn King!
- Specify the exact faction/kingdom ID to which these should apply if it won't be able to be guessed reliably from your culture (and you care)

All of these extensions are off by default, which means that you must enable Mod Configuration Menu in order to use them.